### PR TITLE
chore(deps): update html-validate to v7.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "defu": "5.0.1",
-    "html-validate": "7.2.0"
+    "html-validate": "7.4.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "7.18.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6667,10 +6667,10 @@ html-tags@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
   integrity sha512-+Il6N8cCo2wB/Vd3gqy/8TZhTD3QvcVeQLCnZiGkGCH3JP28IgGAY41giccp2W4R3jfyJPAP318FQTa1yU7K7g==
 
-html-validate@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/html-validate/-/html-validate-7.2.0.tgz#8b69cf5bd630ddc24f1d4c5cff4c56d7b4a0b63c"
-  integrity sha512-AA+DBN6el4FCwH+F4UEO70Kn2ZvVouOhubphVWGIOdssmBg7Q5XKwhOfY187svuFaFRrLqdOGnOtHESiEVErbw==
+html-validate@7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/html-validate/-/html-validate-7.4.0.tgz#536384c0e5c555a015f0bbc113b43da5c5b63a08"
+  integrity sha512-Ho77C5Kq7wvuC6w2eY/tk7rDtodJmmqBMPjyaPZmRpvsqNbK+88n1G4b5NVi5PWcAiTRHFj9NGVaODo1JKIbcA==
   dependencies:
     "@babel/code-frame" "^7.10.0"
     "@html-validate/stylish" "^3.0.0"


### PR DESCRIPTION
Building on #208.

`html-validate` 7.4 adds compatiblity with Jest v29!