### PR TITLE
chore: remove unneeded eslint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,11 @@
 module.exports = {
-  extends: ['@nuxtjs/eslint-config-typescript']
+  extends: ['@nuxtjs/eslint-config-typescript'],
+  overrides: [
+    {
+      files: ['*.test.ts', 'validator.ts'],
+      rules: {
+        'no-console': 'off'
+      }
+    }
+  ]
 }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,3 @@
 module.exports = {
-  extends: ['@nuxtjs/eslint-config-typescript'],
-  rules: {
-    'vue/multi-word-component-names': 'off',
-    'import/named': 'off'
-  }
+  extends: ['@nuxtjs/eslint-config-typescript']
 }


### PR DESCRIPTION
<s>The only warnings left are about `unexpected console statement`s.</s>
I've also turned off console warnings for tests and the validator script. If that's not wanted, that commit can easily be reverted.

@danielroe 