### PR TITLE
feat(checker): add verbosity toggle

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -75,7 +75,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
       <alert>Consider not enabling this if you are using TailwindCSS, as prettier will struggle to cope with parsing the size of your HTML in development mode.</alert>
 
-   - `isVerbose` enables output describing sources to be valid.
+   - `logLevel` sets the verbosity to one of `verbose`, `warning` or `error`.
 
       <alert>You can use this configuration option to turn off console logging for the `No HTML validation errors found for ...` message.</alert>
 
@@ -93,7 +93,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
    {
      htmlValidator: {
        usePrettier: false,
-       isVerbose: true,
+       logLevel: 0,
        failOnError: false,
        options: {
          extends: [

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -75,6 +75,10 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
       <alert>Consider not enabling this if you are using TailwindCSS, as prettier will struggle to cope with parsing the size of your HTML in development mode.</alert>
 
+   - `isVerbose` enables output describing sources to be valid.
+
+      You can use this configuration option to turn off console logging for the `No HTML validation errors found for ...` message.
+
    - `failOnError` will throw an error after running `nuxt generate` if there are any validation errors with the generated pages.
 
       <alert>Useful in continuous integration.</alert>

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -77,7 +77,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
    - `isVerbose` enables output describing sources to be valid.
 
-      You can use this configuration option to turn off console logging for the `No HTML validation errors found for ...` message.
+      <alert>You can use this configuration option to turn off console logging for the `No HTML validation errors found for ...` message.</alert>
 
    - `failOnError` will throw an error after running `nuxt generate` if there are any validation errors with the generated pages.
 
@@ -93,6 +93,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
    {
      htmlValidator: {
        usePrettier: false,
+       isVerbose: true,
        failOnError: false,
        options: {
          extends: [

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -75,7 +75,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
       <alert>Consider not enabling this if you are using TailwindCSS, as prettier will struggle to cope with parsing the size of your HTML in development mode.</alert>
 
-   - `logLevel` sets the verbosity to one of `verbose`, `warning` or `error`.
+   - `logLevel` sets the verbosity to one of `verbose`, `warning` or `error`. It defaults to `verbose` in dev, and `warning` when generating.
 
       <alert>You can use this configuration option to turn off console logging for the `No HTML validation errors found for ...` message.</alert>
 
@@ -93,7 +93,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
    {
      htmlValidator: {
        usePrettier: false,
-       logLevel: 0,
+       logLevel: 'verbose',
        failOnError: false,
        options: {
          extends: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,12 +24,14 @@ export const defaultHtmlValidateConfig: ConfigData = {
 
 export interface ModuleOptions {
   usePrettier?: boolean
+  isVerbose?: boolean
   failOnError?: boolean
   options?: ConfigData
 }
 
 export const DEFAULTS: Required<ModuleOptions> = {
   usePrettier: false,
+  isVerbose: true,
   failOnError: false,
   options: defaultHtmlValidateConfig
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ export const defaultHtmlValidateConfig: ConfigData = {
   }
 }
 
-export enum LogLevel { verbose = 0, warning = 1, error = 2}
+export type LogLevel = 'verbose' | 'warning' | 'error'
 
 export interface ModuleOptions {
   usePrettier?: boolean
@@ -31,9 +31,8 @@ export interface ModuleOptions {
   options?: ConfigData
 }
 
-export const DEFAULTS: Required<ModuleOptions> = {
+export const DEFAULTS: Required<Omit<ModuleOptions, 'logLevel'>> & { logLevel?: LogLevel } = {
   usePrettier: false,
-  logLevel: LogLevel.verbose,
   failOnError: false,
   options: defaultHtmlValidateConfig
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,16 +22,18 @@ export const defaultHtmlValidateConfig: ConfigData = {
   }
 }
 
+export enum LogLevel { verbose = 0, warning = 1, error = 2}
+
 export interface ModuleOptions {
   usePrettier?: boolean
-  isVerbose?: boolean
+  logLevel?: LogLevel
   failOnError?: boolean
   options?: ConfigData
 }
 
 export const DEFAULTS: Required<ModuleOptions> = {
   usePrettier: false,
-  isVerbose: true,
+  logLevel: LogLevel.verbose,
   failOnError: false,
   options: defaultHtmlValidateConfig
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup (_options, nuxt) {
     logger.info(`Using ${chalk.bold('html-validate')} to validate server-rendered HTML`)
 
-    const { usePrettier, failOnError, options } = _options as Required<ModuleOptions>
+    const { usePrettier, failOnError, options, isVerbose } = _options as Required<ModuleOptions>
     if ((nuxt.options as any).htmlValidator?.options?.extends) {
       options.extends = (nuxt.options as any).htmlValidator.options.extends
     }
@@ -42,7 +42,7 @@ export default defineNuxtModule<ModuleOptions>({
       const validatorPath = fileURLToPath(new URL('./runtime/validator', import.meta.url))
       const { useChecker, getValidator } = await import(resolveModule(validatorPath))
       const validator = getValidator(options)
-      const { checkHTML, invalidPages } = useChecker(validator, usePrettier)
+      const { checkHTML, invalidPages } = useChecker(validator, usePrettier, isVerbose)
 
       if (failOnError) {
         const errorIfNeeded = () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup (_options, nuxt) {
     logger.info(`Using ${chalk.bold('html-validate')} to validate server-rendered HTML`)
 
-    const { usePrettier, failOnError, options, isVerbose } = _options as Required<ModuleOptions>
+    const { usePrettier, failOnError, options, logLevel } = _options as Required<ModuleOptions>
     if ((nuxt.options as any).htmlValidator?.options?.extends) {
       options.extends = (nuxt.options as any).htmlValidator.options.extends
     }
@@ -42,7 +42,7 @@ export default defineNuxtModule<ModuleOptions>({
       const validatorPath = fileURLToPath(new URL('./runtime/validator', import.meta.url))
       const { useChecker, getValidator } = await import(resolveModule(validatorPath))
       const validator = getValidator(options)
-      const { checkHTML, invalidPages } = useChecker(validator, usePrettier, isVerbose)
+      const { checkHTML, invalidPages } = useChecker(validator, usePrettier, logLevel)
 
       if (failOnError) {
         const errorIfNeeded = () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,10 +15,10 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: DEFAULTS,
-  async setup (_options, nuxt) {
+  async setup (moduleOptions, nuxt) {
     logger.info(`Using ${chalk.bold('html-validate')} to validate server-rendered HTML`)
 
-    const { usePrettier, failOnError, options, logLevel } = _options as Required<ModuleOptions>
+    const { usePrettier, failOnError, options, logLevel } = moduleOptions as Required<ModuleOptions>
     if ((nuxt.options as any).htmlValidator?.options?.extends) {
       options.extends = (nuxt.options as any).htmlValidator.options.extends
     }
@@ -34,7 +34,7 @@ export default defineNuxtModule<ModuleOptions>({
         config.plugins = config.plugins || []
         config.plugins.push(fileURLToPath(new URL('./runtime/nitro', import.meta.url)))
         config.virtual = config.virtual || {}
-        config.virtual['#html-validator-config'] = `export default ${JSON.stringify(_options)}`
+        config.virtual['#html-validator-config'] = `export default ${JSON.stringify(moduleOptions)}`
       })
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,10 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt: '^2.0.0 || ^3.0.0-rc.7'
     }
   },
-  defaults: DEFAULTS,
+  defaults: nuxt => ({
+    ...DEFAULTS,
+    logLevel: nuxt.options.dev ? 'verbose' : 'warning'
+  }),
   async setup (moduleOptions, nuxt) {
     logger.info(`Using ${chalk.bold('html-validate')} to validate server-rendered HTML`)
 

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -5,7 +5,7 @@ import config from '#html-validator-config'
 
 export default <NitroAppPlugin> function (nitro) {
   const validator = getValidator(config.options)
-  const { checkHTML } = useChecker(validator, config.usePrettier, config.isVerbose)
+  const { checkHTML } = useChecker(validator, config.usePrettier, config.logLevel)
 
   nitro.hooks.hook('render:response', (response: RenderResponse, { event }) => {
     if (typeof response.body === 'string' && (response.headers['Content-Type'] || response.headers['content-type'])?.includes('html')) {

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -5,7 +5,7 @@ import config from '#html-validator-config'
 
 export default <NitroAppPlugin> function (nitro) {
   const validator = getValidator(config.options)
-  const { checkHTML } = useChecker(validator, config.usePrettier)
+  const { checkHTML } = useChecker(validator, config.usePrettier, config.isVerbose)
 
   nitro.hooks.hook('render:response', (response: RenderResponse, { event }) => {
     if (typeof response.body === 'string' && (response.headers['Content-Type'] || response.headers['content-type'])?.includes('html')) {

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import { ConfigData, HtmlValidate, formatterFactory } from 'html-validate'
-
-import { LogLevel } from '../config'
+import type { LogLevel } from '../config'
 
 export const getValidator = (options: ConfigData = {}) => {
   return new HtmlValidate(options)
@@ -10,7 +9,7 @@ export const getValidator = (options: ConfigData = {}) => {
 export const useChecker = (
   validator: HtmlValidate,
   usePrettier = false,
-  logLevel: LogLevel = LogLevel.verbose
+  logLevel: LogLevel = 'verbose'
 ) => {
   const invalidPages: string[] = []
 
@@ -30,7 +29,7 @@ export const useChecker = (
     html = typeof html === 'string' ? html.replace(/ ?data-v-[a-z0-9]+\b/g, '') : html
     const { valid, results } = validator.validateString(html)
 
-    if (valid && !results.length && logLevel <= LogLevel.verbose) {
+    if (valid && !results.length && logLevel === 'verbose') {
       return console.log(
         `No HTML validation errors found for ${chalk.bold(url)}`
       )
@@ -48,10 +47,10 @@ export const useChecker = (
     ].join('\n')
 
     if (valid) {
-      if (logLevel <= LogLevel.warning) {
+      if (logLevel === 'verbose' || logLevel === 'warning') {
         console.warn(message)
       }
-    } else if (logLevel <= LogLevel.error) {
+    } else {
       console.error(message)
     }
   }

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -7,7 +7,8 @@ export const getValidator = (options: ConfigData = {}) => {
 
 export const useChecker = (
   validator: HtmlValidate,
-  usePrettier = false
+  usePrettier = false,
+  isVerbose = true
 ) => {
   const invalidPages: string[] = []
 
@@ -27,7 +28,7 @@ export const useChecker = (
     html = typeof html === 'string' ? html.replace(/ ?data-v-[a-z0-9]+\b/g, '') : html
     const { valid, results } = validator.validateString(html)
 
-    if (valid && !results.length) {
+    if (valid && !results.length && isVerbose) {
       return console.log(
         `No HTML validation errors found for ${chalk.bold(url)}`
       )

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -84,4 +84,22 @@ describe('useChecker', () => {
     const validate = await import('html-validate')
     expect(validate.formatterFactory).not.toHaveBeenCalledWith('codeframe')
   })
+
+  it('logs valid output', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, true)
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).toHaveBeenCalledWith(
+      'No HTML validation errors found for [1mhttps://test.com/[22m'
+    )
+  })
+
+  it('does not log valid output when verbosity is off', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, false)
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+  })
 })

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
-import { LogLevel } from '../src/config'
 import { useChecker } from '../src/runtime/validator'
 
 vi.mock('prettier', () => ({
@@ -44,7 +43,7 @@ describe('useChecker', () => {
 
   it('prints a warning when invalid html is provided and log level is set to verbose', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, LogLevel.verbose)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
@@ -54,7 +53,7 @@ describe('useChecker', () => {
 
   it('prints a warning when invalid html is provided and log level is set to warning', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, LogLevel.warning)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
@@ -64,7 +63,7 @@ describe('useChecker', () => {
 
   it('prints no warning when invalid html is provided and log level is set to error', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, LogLevel.error)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
@@ -121,7 +120,7 @@ describe('useChecker', () => {
 
   it('logs valid output', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, LogLevel.verbose)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
 
     await checker('https://test.com/', Symbol as any)
     expect(console.log).toHaveBeenCalledWith(
@@ -131,7 +130,7 @@ describe('useChecker', () => {
 
   it('does not log valid output when logging on level warning', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, LogLevel.warning)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
 
     await checker('https://test.com/', Symbol as any)
     expect(console.log).not.toHaveBeenCalled()

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { useChecker } from '../src/runtime/validator'
 
@@ -91,7 +92,7 @@ describe('useChecker', () => {
 
     await checker('https://test.com/', Symbol as any)
     expect(console.log).toHaveBeenCalledWith(
-      'No HTML validation errors found for [1mhttps://test.com/[22m'
+      `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
     )
   })
 

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -129,7 +129,7 @@ describe('useChecker', () => {
     )
   })
 
-  it('does not log valid output when logging on level `warning`', async () => {
+  it('does not log valid output when logging on level warning', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, LogLevel.warning)
 


### PR DESCRIPTION
For users who only wish to be notified about error and not about valid sources, I added a verbosity switch to allow disabling the notification about valid sources.

@danielroe before accepting this PR, would you mind adding a [`hacktoberfest-accepted`](https://hacktoberfest.com/) label to it? :)