### PR TITLE
fix: add hyphen to data attribute regexp

### DIFF
--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -24,7 +24,7 @@ export const useChecker = (
     }
 
     // Clean up Vue scoped style attributes
-    html = typeof html === 'string' ? html.replace(/ ?data-v-[a-z0-9]+\b/g, '') : html
+    html = typeof html === 'string' ? html.replace(/ ?data-v-[-a-z0-9]+\b/g, '') : html
     const { valid, results } = validator.validateString(html)
 
     if (valid && !results.length) {


### PR DESCRIPTION
**Issue**
Data attributes with multiple hyphens do not get removed entirely which causes the validator to check incorrect HTML.

**Example**
HTML (note the "-s"):
`<p data-v-f17e0b0c-s>Test</p>`

HTML expected to run through validator:
`<p>Test</p>`

HTML that actually runs through validator:
`<p-s>Test</p>`

html-validator output:
```
4:75  error  Unknown element <p-s>                                     no-unknown-elements
4:85  error  Mismatched close-tag, expected '</p-s>' but found '</p>'  close-order
```

**Minimal reproduction**
https://stackblitz.com/edit/github-cpclz6?file=components/test-outer.vue

**Pull request suggested fix**
I've added a hyphen character inside the matching list so that it will replace data attributes with multiple hyphens.