### PR TITLE
fix(validator): do not log non-existent errors on higher log levels

### DIFF
--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -48,7 +48,13 @@ export const useChecker = (
       ...(formattedResult ? [formattedResult] : [])
     ].join('\n')
 
-    console.error(message)
+    if (valid) {
+      if (logLevel === 'verbose' || logLevel === 'warning') {
+        console.warn(message)
+      }
+    } else {
+      console.error(message)
+    }
   }
 
   return { checkHTML, invalidPages }

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -29,10 +29,12 @@ export const useChecker = (
     html = typeof html === 'string' ? html.replace(/ ?data-v-[-a-z0-9]+\b/g, '') : html
     const { valid, results } = validator.validateString(html)
 
-    if (valid && !results.length && logLevel === 'verbose') {
-      return console.log(
-        `No HTML validation errors found for ${chalk.bold(url)}`
-      )
+    if (valid && !results.length) {
+      if (logLevel === 'verbose') {
+        console.log(`No HTML validation errors found for ${chalk.bold(url)}`)
+      }
+
+      return
     }
 
     if (!valid) { invalidPages.push(url) }
@@ -43,16 +45,10 @@ export const useChecker = (
     const formattedResult = formatter?.(results)
     const message = [
       `HTML validation errors found for ${chalk.bold(url)}`,
-      formattedResult
+      ...(formattedResult ? [formattedResult] : [])
     ].join('\n')
 
-    if (valid) {
-      if (logLevel === 'verbose' || logLevel === 'warning') {
-        console.warn(message)
-      }
-    } else {
-      console.error(message)
-    }
+    console.error(message)
   }
 
   return { checkHTML, invalidPages }

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -45,8 +45,8 @@ export const useChecker = (
     const formattedResult = formatter?.(results)
     const message = [
       `HTML validation errors found for ${chalk.bold(url)}`,
-      ...(formattedResult ? [formattedResult] : [])
-    ].join('\n')
+      formattedResult
+    ].filter(Boolean).join('\n')
 
     if (valid) {
       if (logLevel === 'verbose' || logLevel === 'warning') {

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -47,55 +47,29 @@ describe('useChecker', () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
-  it('does not log valid output when logging on level warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
+  for (const logLevel of ['warning', 'error'] as const) {
+    it(`does not log valid output when logging on level ${logLevel}`, async () => {
+      const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+      const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, logLevel)
 
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
-  })
+      await checker('https://test.com/', Symbol as any)
+      expect(console.log).not.toHaveBeenCalled()
+      expect(console.warn).not.toHaveBeenCalled()
+      expect(console.error).not.toHaveBeenCalled()
+    })
+  }
 
-  it('does not log valid output when logging on level warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
+  for (const logLevel of [undefined, 'verbose', 'warning'] as const) {
+    it(`logs a warning when valid html is provided with warnings and log level is set to ${logLevel}`, async () => {
+      const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
+      const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, logLevel)
 
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
-  })
-
-  it('logs a warning when valid html is provided with warnings', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
-
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
-  })
-
-  it('logs a warning when valid html is provided with warnings and log level is set to verbose', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
-
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
-  })
-
-  it('logs a warning when valid html is provided with warnings and log level is set to warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
-
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
-  })
+      await checker('https://test.com/', Symbol as any)
+      expect(console.log).not.toHaveBeenCalled()
+      expect(console.warn).toHaveBeenCalled()
+      expect(console.error).not.toHaveBeenCalled()
+    })
+  }
 
   it('does not log a warning when valid html is provided with warnings and log level is set to error', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
@@ -107,57 +81,20 @@ describe('useChecker', () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
-  it('logs an error when invalid html is provided', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
+  for (const logLevel of [undefined, 'verbose', 'warning', 'error'] as const) {
+    it(`logs an error when invalid html is provided and log level is set to ${logLevel}`, async () => {
+      const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
+      const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, logLevel)
 
-    await checker('https://test.com/', '<a>Link</a>')
-    expect(mockValidator).toHaveBeenCalled()
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).toHaveBeenCalledWith(
-      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
-    )
-  })
-
-  it('logs an error when invalid html is provided and log level is set to verbose', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
-
-    await checker('https://test.com/', '<a>Link</a>')
-    expect(mockValidator).toHaveBeenCalled()
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).toHaveBeenCalledWith(
-      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
-    )
-  })
-
-  it('logs an error when invalid html is provided and log level is set to warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
-
-    await checker('https://test.com/', '<a>Link</a>')
-    expect(mockValidator).toHaveBeenCalled()
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).toHaveBeenCalledWith(
-      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
-    )
-  })
-
-  it('logs an error when invalid html is provided and log level is set to error', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
-
-    await checker('https://test.com/', '<a>Link</a>')
-    expect(mockValidator).toHaveBeenCalled()
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).toHaveBeenCalledWith(
-      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
-    )
-  })
+      await checker('https://test.com/', '<a>Link</a>')
+      expect(mockValidator).toHaveBeenCalled()
+      expect(console.log).not.toHaveBeenCalled()
+      expect(console.warn).not.toHaveBeenCalled()
+      expect(console.error).toHaveBeenCalledWith(
+        `HTML validation errors found for ${chalk.bold('https://test.com/')}`
+      )
+    })
+  }
 
   it('records urls when invalid html is provided', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -23,52 +23,56 @@ describe('useChecker', () => {
     vi.clearAllMocks()
   })
 
-  it('logs an error', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any)
-
-    await checker('https://test.com/', '<a><a>Link</a></a>')
-    expect(mockValidator).toHaveBeenCalled()
-    expect(console.error).toHaveBeenCalled()
-  })
-
   it('prints an error when invalid html is provided', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
-    expect(console.error).toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
   })
 
-  it('prints a warning when invalid html is provided and log level is set to verbose', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
+  it('prints an error when invalid html is provided and log level is set to verbose', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
-    expect(console.warn).toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
   })
 
-  it('prints a warning when invalid html is provided and log level is set to warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+  it('prints an error when invalid html is provided and log level is set to warning', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
-    expect(console.warn).toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
   })
 
-  it('prints no warning when invalid html is provided and log level is set to error', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+  it('prints an error when invalid html is provided and log level is set to error', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
     expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
   })
 
   it('records urls when invalid html is provided', async () => {
@@ -90,6 +94,10 @@ describe('useChecker', () => {
     expect(mockValidator).toHaveBeenCalledWith(
       '<a>Link</a>'
     )
+    expect(console.log).toHaveBeenCalledWith(
+      `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
+    expect(console.warn).not.toHaveBeenCalled()
     expect(console.error).not.toHaveBeenCalled()
   })
 
@@ -112,7 +120,11 @@ describe('useChecker', () => {
     await checker('https://test.com/', Symbol as any)
     const { format } = await import('prettier')
     expect(format).toHaveBeenCalledWith(Symbol, { parser: 'html' })
-    expect(console.error).toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      `HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
 
     const validate = await import('html-validate')
     expect(validate.formatterFactory).not.toHaveBeenCalledWith('codeframe')
@@ -126,6 +138,8 @@ describe('useChecker', () => {
     expect(console.log).toHaveBeenCalledWith(
       `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
     )
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
   })
 
   it('does not log valid output when logging on level warning', async () => {
@@ -134,5 +148,7 @@ describe('useChecker', () => {
 
     await checker('https://test.com/', Symbol as any)
     expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
   })
 })

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -23,8 +23,92 @@ describe('useChecker', () => {
     vi.clearAllMocks()
   })
 
-  it('prints an error when invalid html is provided', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
+  it('logs valid output', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).toHaveBeenCalledWith(
+      `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('logs valid output', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).toHaveBeenCalledWith(
+      `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('does not log valid output when logging on level warning', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('does not log valid output when logging on level warning', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning when valid html is provided with warnings', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning when valid html is provided with warnings and log level is set to verbose', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning when valid html is provided with warnings and log level is set to warning', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('does not log a warning when valid html is provided with warnings and log level is set to error', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [{ messages: [{ message: '' }] }] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
+
+    await checker('https://test.com/', Symbol as any)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('logs an error when invalid html is provided', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
 
     await checker('https://test.com/', '<a>Link</a>')
@@ -36,8 +120,8 @@ describe('useChecker', () => {
     )
   })
 
-  it('prints an error when invalid html is provided and log level is set to verbose', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
+  it('logs an error when invalid html is provided and log level is set to verbose', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
 
     await checker('https://test.com/', '<a>Link</a>')
@@ -49,8 +133,8 @@ describe('useChecker', () => {
     )
   })
 
-  it('prints an error when invalid html is provided and log level is set to warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
+  it('logs an error when invalid html is provided and log level is set to warning', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
 
     await checker('https://test.com/', '<a>Link</a>')
@@ -62,8 +146,8 @@ describe('useChecker', () => {
     )
   })
 
-  it('prints an error when invalid html is provided and log level is set to error', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
+  it('logs an error when invalid html is provided and log level is set to error', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [{ messages: [{ message: '' }] }] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'error')
 
     await checker('https://test.com/', '<a>Link</a>')
@@ -128,27 +212,5 @@ describe('useChecker', () => {
 
     const validate = await import('html-validate')
     expect(validate.formatterFactory).not.toHaveBeenCalledWith('codeframe')
-  })
-
-  it('logs valid output', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'verbose')
-
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).toHaveBeenCalledWith(
-      `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
-    )
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
-  })
-
-  it('does not log valid output when logging on level warning', async () => {
-    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, 'warning')
-
-    await checker('https://test.com/', Symbol as any)
-    expect(console.log).not.toHaveBeenCalled()
-    expect(console.warn).not.toHaveBeenCalled()
-    expect(console.error).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Previously, the "no error" information early exit required the log level to be set to verbose. Obviously when there is no error it should not log errors on other log levels as well. The tests are more fine grained and cleaned up as well now.