### PR TITLE
fix: ignore `vite-plugin-inspect` generated data attributes

### DIFF
--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -26,7 +26,7 @@ export const useChecker = (
     }
 
     // Clean up Vue scoped style attributes
-    html = typeof html === 'string' ? html.replace(/ ?data-v-[-a-z0-9]+\b/g, '') : html
+    html = typeof html === 'string' ? html.replace(/ ?data-v-[-a-z0-9]+(=["']([-a-z0-9]|\/|:|\.)*["'])?/g, '') : html
     const { valid, results } = validator.validateString(html)
 
     if (valid && !results.length) {

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -122,6 +122,24 @@ describe('useChecker', () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
+  it('ignores vite-plugin-inspect generated data attributes', async () => {
+    const mockValidator = vi.fn().mockImplementation(() => ({ valid: true, results: [] }))
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false)
+
+    await checker(
+      'https://test.com/',
+      '<a style="color:red" class="xxx" data-v-inspector="xxxx/xxx.vue:2:3">Link</a>'
+    )
+    expect(mockValidator).toHaveBeenCalledWith(
+      '<a style="color:red" class="xxx">Link</a>'
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      `No HTML validation errors found for ${chalk.bold('https://test.com/')}`
+    )
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
   it('formats HTML with prettier when asked to do so', async () => {
     const mockValidator = vi.fn().mockImplementation(() => ({ valid: false, results: [] }))
     const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, true)


### PR DESCRIPTION
When I integrate [@nuxt/devtools](https://github.com/nuxt/devtools) or  [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect) in nuxt3 project, it reports an error.

`nuxt.config.ts` config
```typescript
  modules: [
    [
      '@nuxtjs/html-validator',
      {
        usePrettier: true,
      },
    ],
    '@nuxt/devtools',
  ],
```
The code generated by vite-plugin-inspect

![image](https://user-images.githubusercontent.com/12776732/218946436-3295432e-4ea8-4e71-9105-5b6c6cda1c1a.png)

The error message
```
error: failed to tokenize "=\"layouts/...", expected attribute, ">" or "/>" (parser-error) at inline:73:28:
  71 |     <div id="__nuxt">
  72 |       <!--[-->
> 73 |       <div class="relative"="layouts/default.vue:2:3">
     |                            ^
  74 |         <div
  75 |           class="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 md:px-6 xl:px-16"
  76 |          ="components/TheHeader.vue:2:3"
```


