### PR TITLE
fix: ignore uppercase chars in `data-v-*` attributes

### DIFF
--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -26,7 +26,7 @@ export const useChecker = (
     }
 
     // Clean up Vue scoped style attributes
-    html = typeof html === 'string' ? html.replace(/ ?data-v-[-a-z0-9]+(=["']([-a-z0-9]|\/|:|\.)*["'])?/g, '') : html
+    html = typeof html === 'string' ? html.replace(/ ?data-v-[-A-Za-z0-9]+(=["']([-A-Za-z0-9]|\/|:|\.)*["'])?/g, '') : html
     const { valid, results } = validator.validateString(html)
 
     if (valid && !results.length) {

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -128,7 +128,7 @@ describe('useChecker', () => {
 
     await checker(
       'https://test.com/',
-      '<a style="color:red" class="xxx" data-v-inspector="xxxx/xxx.vue:2:3">Link</a>'
+      '<a style="color:red" class="xxx" data-v-inspector="Xxxx/Xxx.vue:2:3">Link</a>'
     )
     expect(mockValidator).toHaveBeenCalledWith(
       '<a style="color:red" class="xxx">Link</a>'


### PR DESCRIPTION
Fixed a regex that did not take into account uppercase letters.

Close #337 