### PR TITLE
feat: add `html-validator:check` nitro hook

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,10 +29,18 @@ export interface ModuleOptions {
   logLevel?: LogLevel
   failOnError?: boolean
   options?: ConfigData
+  /**
+   * allow to hook into `html-validator`
+   * enabling this option block the response until the HTML check and the hook has finished
+   *
+   * @default false
+   */
+  hookable: boolean
 }
 
 export const DEFAULTS: Required<Omit<ModuleOptions, 'logLevel'>> & { logLevel?: LogLevel } = {
   usePrettier: false,
   failOnError: false,
-  options: defaultHtmlValidateConfig
+  options: defaultHtmlValidateConfig,
+  hookable: false
 }

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -12,7 +12,7 @@ export default <NitroAppPlugin> function (nitro) {
       // Block the response only if it's not hookable
       const promise = checkHTML(event.req.url, response.body)
       if (config.hookable) {
-        await nitro.hooks.callHook('html-validator', await promise, response, { event })
+        await nitro.hooks.callHook('html-validator:check', await promise, response, { event })
       }
     }
   })

--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -34,7 +34,7 @@ export const useChecker = (
         console.log(`No HTML validation errors found for ${chalk.bold(url)}`)
       }
 
-      return
+      return { valid, results }
     }
 
     if (!valid) { invalidPages.push(url) }
@@ -54,6 +54,8 @@ export const useChecker = (
     } else {
       console.error(message)
     }
+
+    return { valid, results }
   }
 
   return { checkHTML, invalidPages }


### PR DESCRIPTION
resolve #368 


Hi :wave: 

This PR adds a small feature so we can hook into `html-validator`. This can be nice to have so other modules/plugins or just projects can add some implementation with `@nuxt/html-validator` instead of adding the package twice