### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 1. Add `@nuxtjs/html-validator` as a dev dependency to your project
 
 ```bash
-yarn add @nuxtjs/html-validator --dev # or npm install @nuxtjs/html-validator --save-dev
+npx nuxi@latest module add html-validator
 ```
 
 2. Add `@nuxtjs/html-validator` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -21,18 +21,9 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 ## Quick start
 
 ### Install
-
-::code-group
- ```bash [pnpm]
-  pnpm i -D @nuxtjs/html-validator
-  ```
- ```bash [Yarn]
-  yarn add @nuxtjs/html-validator --dev
-  ```
- ```bash [npm]
-  npm install @nuxtjs/html-validator --save-dev
-  ```
-::
+```bash
+npx nuxi@latest module add html-validator
+```
 
 ### nuxt.config.js
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
