### PR TITLE
fix(validator): account for empty Vue scoped style attributes

### DIFF
--- a/src/runtime/validator.ts
+++ b/src/runtime/validator.ts
@@ -29,7 +29,7 @@ export const useChecker = (
     }
 
     // Clean up Vue scoped style attributes
-    html = typeof html === 'string' ? html.replace(/ ?data-v-[-A-Za-z0-9]+(=["'][^"']+["'])?/g, '') : html
+    html = typeof html === 'string' ? html.replace(/ ?data-v-[-A-Za-z0-9]+(=["'][^"']*["'])?/g, '') : html
     const { valid, results } = await validator.validateString(html)
 
     if (valid && !results.length) {


### PR DESCRIPTION
In an `svg` tag I have many `data-v-...` attributes with an empty value `=""`. These are currently replaced by this module's regex incorrectly.

What's currently detected:

![image](https://github.com/nuxt-modules/html-validator/assets/4778485/f25ea4ea-1ebf-4c26-b9ac-d78ba6aba5e0)

What this PR changes:

![image](https://github.com/nuxt-modules/html-validator/assets/4778485/ca19eed2-c966-478e-ab1f-4cee322e920b)

Disclaimer: Maybe there shouldn't even be `data-v-...` attributes with their value set to `=""`. I see other `data-v-...` attributes with no suffix at all. The existing regex let's me think that the actual bug might be some tooling in my project which incorrectly allows `data-v-...` attributes to have `=""`, but which it shouldn't. Do you have any insight into this @danielroe?