### PR TITLE
fix: skip validation on redirect HTML

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,3 +50,5 @@ export const DEFAULTS: Required<Omit<ModuleOptions, 'logLevel'>> & { logLevel?: 
   hookable: false,
   ignore: [/\.(xml|rss|json)$/],
 }
+
+export const NuxtRedirectHtmlRegex = /<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=([^"]+)"><\/head><\/html>/

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,7 @@ import { isWindows } from 'std-env'
 import { genArrayFromRaw, genObjectFromRawEntries } from 'knitwork'
 
 import { createResolver, defineNuxtModule, isNuxt2, logger, resolvePath } from '@nuxt/kit'
-import { DEFAULTS } from './config'
+import { DEFAULTS, NuxtRedirectHtmlRegex } from './config'
 import type { ModuleOptions } from './config'
 
 export type { ModuleOptions }
@@ -86,6 +86,9 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt.hook('nitro:init', (nitro) => {
         nitro.hooks.hook('prerender:generate', (route) => {
           if (!route.contents || !route.fileName?.endsWith('.html')) {
+            return
+          }
+          if (route.contents.match(NuxtRedirectHtmlRegex)) {
             return
           }
           checkHTML(route.route, route.contents)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using redirects via route rules it injects a HTML file with a http-equiv refresh to trigger a client-side redirect if the server redirects fails for some reason.

The module currently will warn about these files which is not ideal. For users using the Sitemap module they'll always get a warning as we setup redirects for them.

```
 ERROR  HTML validation errors found for /sitemap.xml                                                                                                                                       5:20:11 pm

inline
  1:17  error  <html> is missing required "lang" attribute  element-required-attributes
  1:17  error  <html> element must have <body> as content   element-required-content
  1:23  error  <head> element must have <title> as content  element-required-content

✖ 3 problems (3 errors, 0 warnings)
                                                                                                                                                                                                        
More information:
  https://html-validate.org/rules/element-required-attributes.html
  https://html-validate.org/rules/element-required-content.html
```

This regex is taken from the Sitemap module itself as it needs to filter out the same paths.

Ideally we'd have access to the headers so we could check if it's redirecting instead of relying on this regex which is a bit hacky.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
