### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,16 +2,20 @@ packages:
   - docs
   - playground
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - sharp
-  - vue-demi
-
-onlyBuiltDependencies:
-  - better-sqlite3
-
 overrides:
   "@nuxt/content": "^3.11.0"
   "@nuxt/kit": "^4.0.0"
   "@nuxtjs/html-validator": "link:./"
+
+shamefullyHoist: true
+
+strictPeerDependencies: false
+
+allowBuilds:
+  '@parcel/watcher': false
+  better-sqlite3: true
+  esbuild: false
+  sharp: false
+  simple-git-hooks: true
+  unrs-resolver: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`