### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/playground/pages/ignored.vue
+++ b/playground/pages/ignored.vue
@@ -1,0 +1,5 @@
+<template>
+  <a>
+    <a>This invalid markup should not be validated.</a>
+  </a>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -65,7 +65,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (!nuxt.options.dev) {
       const validatorPath = await resolvePath(fileURLToPath(new URL('./runtime/validator', import.meta.url)))
-      const { useChecker, getValidator } = await import(isWindows ? pathToFileURL(validatorPath).href : validatorPath)
+      const { useChecker, getValidator, isIgnored } = await import(isWindows ? pathToFileURL(validatorPath).href : validatorPath)
       const validator = getValidator(options)
       const { checkHTML, invalidPages } = useChecker(validator, usePrettier, logLevel)
 
@@ -86,6 +86,9 @@ export default defineNuxtModule<ModuleOptions>({
             return
           }
           if (route.contents.match(NuxtRedirectHtmlRegex)) {
+            return
+          }
+          if (isIgnored(route.route, moduleOptions.ignore)) {
             return
           }
           checkHTML(route.route, route.contents)

--- a/test/module-prerender.test.ts
+++ b/test/module-prerender.test.ts
@@ -20,7 +20,8 @@ await setup({
     hooks: {
       'modules:before'() {
         const nuxt = useNuxt()
-        nuxt.options.nitro.prerender = { routes: ['/', '/redirect'] }
+        nuxt.options.htmlValidator = { ignore: ['/ignored'] }
+        nuxt.options.nitro.prerender = { routes: ['/', '/ignored', '/redirect'] }
       },
     },
   },
@@ -55,6 +56,12 @@ describe('Nuxt prerender', () => {
     expect(html).toMatchInlineSnapshot(`"<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=/"></head></html>"`)
     expect(console.error).not.toHaveBeenCalledWith(
       expect.stringContaining('<html> element must have <body> as content'),
+    )
+  })
+
+  it('ignores configured pages', () => {
+    expect(console.error).not.toHaveBeenCalledWith(
+      expect.stringContaining('/ignored'),
     )
   })
 })


### PR DESCRIPTION
## Summary

Respect `htmlValidator.ignore` while validating prerendered routes.

Fixes #768.

## Changes

- reuse the existing `isIgnored` matcher in the production `prerender:generate` hook
- add a Nuxt prerender regression fixture for an ignored invalid page
- keep validation coverage for non-ignored and redirect pages

## Validation

- `pnpm vitest run test/module-prerender.test.ts` (3 passed)
- `pnpm test` (24 passed, 1 todo, 1 skipped file)
- `pnpm lint`
- `pnpm build`
- `git diff --check`
